### PR TITLE
Fixed the require_once call to follow Magento's (app/local - app/core) logic

### DIFF
--- a/app/code/community/OlegKoval/ProductReviewCaptcha/controllers/ProductController.php
+++ b/app/code/community/OlegKoval/ProductReviewCaptcha/controllers/ProductController.php
@@ -8,7 +8,7 @@
  * @author      Oleg Koval <oleh.koval@gmail.com>
  */
 //include controller to override it
-require_once(Mage::getBaseDir('app') . DS .'code'. DS .'core'. DS .'Mage'. DS .'Review'. DS .'controllers'. DS .'ProductController.php');
+require_once 'Mage/Review/controllers/ProductController.php';
 
 class OlegKoval_ProductReviewCaptcha_ProductController extends Mage_Review_ProductController {
     const XML_PATH_PRC_ENABLED     = 'catalog/review/prc_enabled';


### PR DESCRIPTION
...ductController.php

My ProductController.php file exists in app/local/ since I made some modifications to it. I needed this plugin to extend my modified controller from app/local/ if it exists and fall back to app/core if needed.
